### PR TITLE
Feat: Integración con Elementor y widgets de cupones/formulario

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# WP-Cupon-Whatsapp
-Plugin Cupón Whatsapp
+# WP Cupón WhatsApp
+
+**Contributors:** (Tu nombre/nombre de empresa aquí)
+**Tags:** cupones, whatsapp, woocommerce, elementor, lealtad, canje
+**Requires at least:** 5.0
+**Tested up to:** (Versión de WordPress con la que probaste)
+**Stable tag:** 1.1.0
+**License:** GPLv2 or later
+**License URI:** https://www.gnu.org/licenses/gpl-2.0.html
+
+Un plugin para WordPress que integra un sistema de gestión y canje de cupones a través de WhatsApp, con funcionalidades para programas de lealtad y compatibilidad con WooCommerce y Elementor.
+
+## Descripción
+
+WP Cupón WhatsApp te permite crear y gestionar diferentes tipos de cupones que tus clientes pueden visualizar y solicitar canjear a través de mensajes de WhatsApp. Este plugin está diseñado para facilitar la implementación de programas de fidelización y promociones directas.
+
+Características principales:
+
+*   Gestión de cupones públicos y de lealtad.
+*   Formulario de solicitud de adhesión para comercios e instituciones.
+*   Integración con WooCommerce para el tipo de post `shop_coupon`.
+*   Páginas de "Mis Cupones" y "Cupones Públicos" mediante shortcodes.
+*   Integración con Google reCAPTCHA v2 para formularios.
+*   Widgets de Elementor para mostrar listas de cupones y el formulario de adhesión.
+*   Panel de administración para ajustes, estadísticas y exportación de datos.
+
+## Instalación
+
+1.  Sube la carpeta `wp-cupon-whatsapp` al directorio `/wp-content/plugins/`.
+2.  Activa el plugin a través del menú 'Plugins' en WordPress.
+3.  Ve a "Cupones WPCW" > "Ajustes" para configurar el plugin (ej. reCAPTCHA, campos obligatorios).
+4.  Utiliza los shortcodes o los widgets de Elementor para mostrar los cupones y formularios en tu sitio.
+
+## Shortcodes
+
+*   `[wpcw_solicitud_adhesion_form]`: Muestra el formulario para que comercios/instituciones soliciten adherirse.
+*   `[wpcw_mis_cupones]`: Muestra los cupones de lealtad disponibles para el usuario actualmente logueado.
+*   `[wpcw_cupones_publicos]`: Muestra una lista de todos los cupones públicos disponibles.
+
+## Integración con Elementor
+
+Este plugin incluye widgets para Elementor que te permiten integrar fácilmente la funcionalidad de cupones en páginas construidas con el editor de Elementor.
+
+### Widgets Disponibles
+
+Para encontrar los widgets, busca la categoría **"WP Cupón WhatsApp"** en el panel de widgets de Elementor.
+
+1.  **Lista de Cupones WPCW**
+    *   **Descripción:** Muestra una lista personalizable de cupones. Puedes configurar el tipo de cupones a mostrar (públicos o de lealtad para el usuario logueado), la cantidad, el orden, y qué elementos de la tarjeta de cupón son visibles (imagen, código, descripción).
+    *   **Personalización:** Ofrece amplias opciones de estilo para el grid de cupones, las tarjetas individuales, imágenes, textos y el botón de canje, todo configurable desde la pestaña "Estilo" de Elementor.
+
+2.  **Formulario Solicitud Adhesión WPCW**
+    *   **Descripción:** Incrusta el formulario de solicitud de adhesión para que nuevos comercios o instituciones puedan registrarse en tu programa de cupones.
+    *   **Personalización:** Permite modificar los textos y etiquetas del formulario. Ofrece controles de estilo para las etiquetas, campos de entrada, el botón de envío y los mensajes de error/éxito a través de la pestaña "Estilo" de Elementor. La integración con reCAPTCHA (si está configurada en los ajustes del plugin) también es compatible.
+
+### Uso
+Simplemente arrastra y suelta los widgets en tus páginas de Elementor y configúralos usando los controles disponibles en el panel lateral del editor.
+
+## Changelog
+
+### 1.1.0 (Fecha Actual)
+*   NEW: Añadida integración con Elementor.
+*   NEW: Widget "Lista de Cupones WPCW" para Elementor.
+*   NEW: Widget "Formulario Solicitud Adhesión WPCW" para Elementor.
+*   NEW: Categoría "WP Cupón WhatsApp" en Elementor.
+
+### 1.0.0
+*   Lanzamiento inicial del plugin.
+
+## Frequently Asked Questions
+
+*Próximamente*

--- a/elementor/elementor-addon.php
+++ b/elementor/elementor-addon.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Elementor Addon for WP Cupón WhatsApp
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Main Elementor Addon Class
+ *
+ * The main class that initiates and runs the Elementor addon.
+ *
+ * @since 1.1.0
+ */
+final class WPCW_Elementor_Addon {
+
+	/**
+	 * Plugin Version
+	 *
+	 * @since 1.1.0
+	 * @var string The plugin version.
+	 */
+	const VERSION = '1.1.0';
+
+	/**
+	 * Minimum Elementor Version
+	 *
+	 * @since 1.1.0
+	 * @var string Minimum Elementor version required to run the addon.
+	 */
+	const MINIMUM_ELEMENTOR_VERSION = '3.0.0';
+
+	/**
+	 * Minimum PHP Version
+	 *
+	 * @since 1.1.0
+	 * @var string Minimum PHP version required to run the addon.
+	 */
+	const MINIMUM_PHP_VERSION = '7.0';
+
+	/**
+	 * Instance
+	 *
+	 * @since 1.1.0
+	 * @access private
+	 * @static
+	 * @var WPCW_Elementor_Addon The single instance of the class.
+	 */
+	private static $_instance = null;
+
+	/**
+	 * Instance
+	 *
+	 * Ensures only one instance of the class is loaded or can be loaded.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @static
+	 * @return WPCW_Elementor_Addon An instance of the class.
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 */
+	public function __construct() {
+		add_action( 'plugins_loaded', [ $this, 'on_plugins_loaded' ] );
+	}
+
+	/**
+	 * Load Textdomain
+	 *
+	 * Load plugin localization files.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 */
+	public function i18n() {
+		// This is handled by the main plugin file
+	}
+
+	/**
+	 * On Plugins Loaded
+	 *
+	 * Checks if Elementor has loaded, and performs some compatibility checks.
+	 * If all checks pass, registers the actions.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 */
+	public function on_plugins_loaded() {
+		if ( $this->is_compatible() ) {
+			add_action( 'elementor/init', [ $this, 'init' ] );
+		}
+	}
+
+	/**
+	 * Compatibility Checks
+	 *
+	 * Checks if the installed version of Elementor meets the addon's minimum requirement.
+	 * Checks if the installed PHP version meets the addon's minimum requirement.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @return bool True if compatible, False otherwise.
+	 */
+	public function is_compatible() {
+		// Check if Elementor installed and activated
+		if ( ! did_action( 'elementor/loaded' ) ) {
+			add_action( 'admin_notices', [ $this, 'admin_notice_missing_main_plugin' ] );
+			return false;
+		}
+
+		// Check for required Elementor version
+		if ( ! version_compare( ELEMENTOR_VERSION, self::MINIMUM_ELEMENTOR_VERSION, '>=' ) ) {
+			add_action( 'admin_notices', [ $this, 'admin_notice_minimum_elementor_version' ] );
+			return false;
+		}
+
+		// Check for required PHP version
+		if ( version_compare( PHP_VERSION, self::MINIMUM_PHP_VERSION, '<' ) ) {
+			add_action( 'admin_notices', [ $this, 'admin_notice_minimum_php_version' ] );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Initialize the addon
+	 *
+	 * Load the plugin classes and initialize the addon.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 */
+	public function init() {
+		// Add Plugin actions
+		add_action( 'elementor/widgets/register', [ $this, 'register_widgets' ] );
+		add_action( 'elementor/elements/categories_registered', [ $this, 'register_widget_categories' ] );
+        // Elementor 3.5.0+ uses elementor/widgets/register hook.
+        // For older versions, use elementor/widgets/widgets_registered.
+        // The 'register' hook is more appropriate for modern Elementor.
+	}
+
+	/**
+	 * Register Widgets
+	 *
+	 * Register new Elementor widgets.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @param \Elementor\Widgets_Manager $widgets_manager Elementor widgets manager.
+	 */
+	public function register_widgets( $widgets_manager ) {
+		// Define the path to your widgets directory
+		$widgets_dir = WPCW_PLUGIN_DIR . 'elementor/widgets/';
+
+		// Include Widget files
+		require_once( $widgets_dir . 'widget-cupones-lista.php' );
+		require_once( $widgets_dir . 'widget-formulario-adhesion.php' );
+
+		// Register Widgets
+		$widgets_manager->register( new \WPCW_Elementor_Cupones_Lista_Widget() );
+		$widgets_manager->register( new \WPCW_Elementor_Formulario_Adhesion_Widget() );
+	}
+
+    /**
+	 * Register Widget Categories
+	 *
+	 * Adds a custom category to the Elementor widget panel.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @param \Elementor\Elements_Manager $elements_manager
+	 */
+	public function register_widget_categories( $elements_manager ) {
+		$elements_manager->add_category(
+			'wpcw-categoria',
+			[
+				'title' => __( 'WP Cupón WhatsApp', 'wp-cupon-whatsapp' ),
+				'icon' => 'fa fa-whatsapp', // Or your custom icon class
+			]
+		);
+	}
+
+
+	/**
+	 * Admin notice
+	 *
+	 * Warning when the site doesn't have Elementor installed or activated.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 */
+	public function admin_notice_missing_main_plugin() {
+		if ( isset( $_GET['activate'] ) ) unset( $_GET['activate'] );
+		$message = sprintf(
+			/* translators: 1: Plugin name 2: Elementor */
+			esc_html__( '"%1$s" requires "%2$s" to be installed and activated.', 'wp-cupon-whatsapp' ),
+			'<strong>' . esc_html__( 'WP Cupón WhatsApp Elementor Addon', 'wp-cupon-whatsapp' ) . '</strong>',
+			'<strong>' . esc_html__( 'Elementor', 'wp-cupon-whatsapp' ) . '</strong>'
+		);
+		printf( '<div class="notice notice-warning is-dismissible"><p>%1$s</p></div>', $message );
+	}
+
+	/**
+	 * Admin notice
+	 *
+	 * Warning when the site doesn't have a minimum required Elementor version.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 */
+	public function admin_notice_minimum_elementor_version() {
+		if ( isset( $_GET['activate'] ) ) unset( $_GET['activate'] );
+		$message = sprintf(
+			/* translators: 1: Plugin name 2: Elementor 3: Minimum Elementor version */
+			esc_html__( '"%1$s" requires "%2$s" version %3$s or greater.', 'wp-cupon-whatsapp' ),
+			'<strong>' . esc_html__( 'WP Cupón WhatsApp Elementor Addon', 'wp-cupon-whatsapp' ) . '</strong>',
+			'<strong>' . esc_html__( 'Elementor', 'wp-cupon-whatsapp' ) . '</strong>',
+			self::MINIMUM_ELEMENTOR_VERSION
+		);
+		printf( '<div class="notice notice-warning is-dismissible"><p>%1$s</p></div>', $message );
+	}
+
+	/**
+	 * Admin notice
+	 *
+	 * Warning when the site doesn't have a minimum required PHP version.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 */
+	public function admin_notice_minimum_php_version() {
+		if ( isset( $_GET['activate'] ) ) unset( $_GET['activate'] );
+		$message = sprintf(
+			/* translators: 1: Plugin name 2: PHP 3: Minimum PHP version */
+			esc_html__( '"%1$s" requires "%2$s" version %3$s or greater.', 'wp-cupon-whatsapp' ),
+			'<strong>' . esc_html__( 'WP Cupón WhatsApp Elementor Addon', 'wp-cupon-whatsapp' ) . '</strong>',
+			'<strong>' . esc_html__( 'PHP', 'wp-cupon-whatsapp' ) . '</strong>',
+			self::MINIMUM_PHP_VERSION
+		);
+		printf( '<div class="notice notice-warning is-dismissible"><p>%1$s</p></div>', $message );
+	}
+}
+
+// Instantiate WPCW_Elementor_Addon
+WPCW_Elementor_Addon::instance();
+
+// Create widgets directory if it doesn't exist
+if ( ! is_dir( WPCW_PLUGIN_DIR . 'elementor/widgets' ) ) {
+    mkdir( WPCW_PLUGIN_DIR . 'elementor/widgets', 0755, true );
+}

--- a/elementor/widgets/widget-cupones-lista.php
+++ b/elementor/widgets/widget-cupones-lista.php
@@ -1,0 +1,1056 @@
+<?php
+/**
+ * Elementor Lista de Cupones Widget.
+ *
+ * Elementor widget that displays a list of WPCW coupons.
+ *
+ * @since 1.1.0
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class WPCW_Elementor_Cupones_Lista_Widget extends \Elementor\Widget_Base {
+
+	/**
+	 * Get widget name.
+	 *
+	 * Retrieve Lista de Cupones widget name.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @return string Widget name.
+	 */
+	public function get_name() {
+		return 'wpcw-cupones-lista';
+	}
+
+	/**
+	 * Get widget title.
+	 *
+	 * Retrieve Lista de Cupones widget title.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @return string Widget title.
+	 */
+	public function get_title() {
+		return esc_html__( 'Lista de Cupones WPCW', 'wp-cupon-whatsapp' );
+	}
+
+	/**
+	 * Get widget icon.
+	 *
+	 * Retrieve Lista de Cupones widget icon.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @return string Widget icon.
+	 */
+	public function get_icon() {
+		return 'eicon-bullet-list';
+	}
+
+	/**
+	 * Get widget categories.
+	 *
+	 * Retrieve the list of categories the Lista de Cupones widget belongs to.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @return array Widget categories.
+	 */
+	public function get_categories() {
+		return [ 'wpcw-categoria' ];
+	}
+
+    /**
+	 * Get script depends.
+	 *
+	 * Retrieve the list of scripts the widget depends on.
+	 *
+	 * @since 1.1.0
+	 * @access public
+	 * @return array Widget scripts dependencies.
+	 */
+    public function get_script_depends() {
+        // Depend on the main plugin's canje handler script
+        return [ 'wpcw-canje-handler' ];
+    }
+
+	/**
+	 * Register Lista de Cupones widget controls.
+	 *
+	 * Add input fields to allow the user to customize the widget settings.
+	 *
+	 * @since 1.1.0
+	 * @access protected
+	 */
+	protected function _register_controls() {
+
+		// Content Tab
+		$this->start_controls_section(
+			'section_content_source',
+			[
+				'label' => esc_html__( 'Fuente de Cupones', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
+			]
+		);
+
+		$this->add_control(
+			'tipo_cupon',
+			[
+				'label' => esc_html__( 'Tipo de Cupones a Mostrar', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SELECT,
+				'default' => 'publicos',
+				'options' => [
+					'publicos' => esc_html__( 'Cupones Públicos', 'wp-cupon-whatsapp' ),
+					'mis_cupones' => esc_html__( 'Mis Cupones de Lealtad', 'wp-cupon-whatsapp' ),
+				],
+				'description' => esc_html__( 'Selecciona si mostrar cupones públicos o los cupones de lealtad del usuario actual.', 'wp-cupon-whatsapp' ),
+			]
+		);
+
+		$this->add_control(
+			'mensaje_no_logueado',
+			[
+				'label' => esc_html__( 'Mensaje (Usuario no logueado)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXTAREA,
+				'default' => esc_html__( 'Por favor, inicia sesión para ver tus cupones disponibles.', 'wp-cupon-whatsapp' ),
+				'condition' => [
+					'tipo_cupon' => 'mis_cupones',
+				],
+			]
+		);
+
+        $default_my_account_url = function_exists('wc_get_page_permalink') ? wc_get_page_permalink('myaccount') : wp_login_url();
+		$this->add_control(
+			'enlace_login',
+			[
+				'label' => esc_html__( 'Enlace a Página de Login/Mi Cuenta', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::URL,
+				'default' => [
+                    'url' => $default_my_account_url,
+                    'is_external' => false,
+                    'nofollow' => true,
+                ],
+				'condition' => [
+					'tipo_cupon' => 'mis_cupones',
+				],
+                'dynamic' => [
+                    'active' => true,
+                ]
+			]
+		);
+
+		$this->end_controls_section();
+
+		$this->start_controls_section(
+			'section_content_query',
+			[
+				'label' => esc_html__( 'Consulta', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
+			]
+		);
+
+		$this->add_control(
+			'numero_cupones',
+			[
+				'label' => esc_html__( 'Número de Cupones', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::NUMBER,
+				'default' => 12,
+				'min' => -1,
+				'description' => esc_html__( '-1 para mostrar todos los cupones.', 'wp-cupon-whatsapp' ),
+			]
+		);
+
+		$this->add_control(
+			'ordenar_por',
+			[
+				'label' => esc_html__( 'Ordenar por', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SELECT,
+				'default' => 'date',
+				'options' => [
+					'date' => esc_html__( 'Fecha de Publicación', 'wp-cupon-whatsapp' ),
+					'title' => esc_html__( 'Título (Código Cupón)', 'wp-cupon-whatsapp' ),
+					'rand' => esc_html__( 'Aleatorio', 'wp-cupon-whatsapp' ),
+					'modified' => esc_html__( 'Última Modificación', 'wp-cupon-whatsapp' ),
+				],
+			]
+		);
+
+		$this->add_control(
+			'orden',
+			[
+				'label' => esc_html__( 'Orden', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::CHOOSE,
+				'options' => [
+					'ASC' => [
+						'title' => esc_html__( 'Ascendente', 'wp-cupon-whatsapp' ),
+						'icon' => 'eicon-sort-up',
+					],
+					'DESC' => [
+						'title' => esc_html__( 'Descendente', 'wp-cupon-whatsapp' ),
+						'icon' => 'eicon-sort-down',
+					],
+				],
+				'default' => 'DESC',
+				'toggle' => false,
+			]
+		);
+
+		$this->end_controls_section();
+
+        $this->start_controls_section(
+			'section_content_layout',
+			[
+				'label' => esc_html__( 'Diseño de Tarjeta', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
+			]
+		);
+
+        $this->add_control(
+			'mostrar_imagen',
+			[
+				'label' => esc_html__( 'Mostrar Imagen del Cupón', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SWITCHER,
+				'label_on' => esc_html__( 'Sí', 'wp-cupon-whatsapp' ),
+				'label_off' => esc_html__( 'No', 'wp-cupon-whatsapp' ),
+				'return_value' => 'yes',
+				'default' => 'yes',
+			]
+		);
+
+        $this->add_control(
+			'mostrar_codigo',
+			[
+				'label' => esc_html__( 'Mostrar Código del Cupón', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SWITCHER,
+				'label_on' => esc_html__( 'Sí', 'wp-cupon-whatsapp' ),
+				'label_off' => esc_html__( 'No', 'wp-cupon-whatsapp' ),
+				'return_value' => 'yes',
+				'default' => 'yes',
+			]
+		);
+
+        $this->add_control(
+			'mostrar_descripcion',
+			[
+				'label' => esc_html__( 'Mostrar Descripción', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SWITCHER,
+				'label_on' => esc_html__( 'Sí', 'wp-cupon-whatsapp' ),
+				'label_off' => esc_html__( 'No', 'wp-cupon-whatsapp' ),
+				'return_value' => 'yes',
+				'default' => 'yes',
+			]
+		);
+
+        $this->add_control(
+			'longitud_descripcion',
+			[
+				'label' => esc_html__( 'Longitud de Descripción (palabras)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::NUMBER,
+				'default' => 20,
+                'min' => 1,
+				'condition' => [
+					'mostrar_descripcion' => 'yes',
+				],
+			]
+		);
+
+        $this->add_control(
+			'texto_boton_canje',
+			[
+				'label' => esc_html__( 'Texto del Botón de Canje', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXT,
+				'default' => esc_html__( 'Canjear Cupón', 'wp-cupon-whatsapp' ),
+                'dynamic' => [
+                    'active' => true,
+                ]
+			]
+		);
+
+        $this->add_control(
+			'mensaje_no_cupones',
+			[
+				'label' => esc_html__( 'Mensaje (No hay cupones)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXTAREA,
+				'default' => esc_html__( 'No hay cupones disponibles en este momento.', 'wp-cupon-whatsapp' ),
+                'dynamic' => [
+                    'active' => true,
+                ]
+			]
+		);
+
+
+        $this->end_controls_section();
+
+        // Style Tab
+        $this->start_controls_section(
+			'section_style_grid',
+			[
+				'label' => esc_html__( 'Grid de Cupones', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+
+        $this->add_responsive_control(
+            'columnas',
+            [
+                'label' => esc_html__( 'Columnas', 'wp-cupon-whatsapp' ),
+                'type' => \Elementor\Controls_Manager::SELECT,
+                'default' => '3',
+                'tablet_default' => '2',
+                'mobile_default' => '1',
+                'options' => [
+                    '1' => '1',
+                    '2' => '2',
+                    '3' => '3',
+                    '4' => '4',
+                    '5' => '5',
+                    '6' => '6',
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .wpcw-coupons-grid' => 'grid-template-columns: repeat({{VALUE}}, 1fr);',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+			'espaciado_columnas',
+			[
+				'label' => esc_html__( 'Espaciado entre Columnas', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SLIDER,
+				'size_units' => [ 'px', 'em', 'rem' ],
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 100,
+					],
+				],
+				'default' => [
+					'unit' => 'px',
+					'size' => 15,
+				],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupons-grid' => 'column-gap: {{SIZE}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->add_responsive_control(
+			'espaciado_filas',
+			[
+				'label' => esc_html__( 'Espaciado entre Filas', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SLIDER,
+				'size_units' => [ 'px', 'em', 'rem' ],
+				'range' => [
+					'px' => [
+						'min' => 0,
+						'max' => 100,
+					],
+				],
+				'default' => [
+					'unit' => 'px',
+					'size' => 15,
+				],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupons-grid' => 'row-gap: {{SIZE}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+			'section_style_card',
+			[
+				'label' => esc_html__( 'Tarjeta de Cupón', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Background::get_type(),
+			[
+				'name' => 'card_background',
+				'label' => esc_html__( 'Fondo', 'wp-cupon-whatsapp' ),
+				'types' => [ 'classic', 'gradient' ],
+				'selector' => '{{WRAPPER}} .wpcw-coupon-card',
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Border::get_type(),
+			[
+				'name' => 'card_border',
+				'selector' => '{{WRAPPER}} .wpcw-coupon-card',
+			]
+		);
+
+        $this->add_responsive_control(
+			'card_border_radius',
+			[
+				'label' => esc_html__( 'Radio del Borde', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-card' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Box_Shadow::get_type(),
+			[
+				'name' => 'card_box_shadow',
+				'selector' => '{{WRAPPER}} .wpcw-coupon-card',
+			]
+		);
+
+        $this->add_responsive_control(
+			'card_padding',
+			[
+				'label' => esc_html__( 'Padding', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-card' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+			'section_style_image',
+			[
+				'label' => esc_html__( 'Imagen del Cupón', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+                'condition' => [
+                    'mostrar_imagen' => 'yes',
+                ]
+			]
+		);
+
+        $this->add_responsive_control(
+			'image_border_radius',
+			[
+				'label' => esc_html__( 'Radio del Borde', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-image-wrapper img' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                    '{{WRAPPER}} .wpcw-coupon-image-placeholder' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->add_responsive_control(
+			'image_height',
+			[
+				'label' => esc_html__( 'Altura', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SLIDER,
+				'size_units' => [ 'px', 'vh' ],
+                'range' => [
+					'px' => [
+						'min' => 50,
+						'max' => 500,
+					],
+				],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-image-wrapper img' => 'height: {{SIZE}}{{UNIT}}; object-fit: cover;',
+                    '{{WRAPPER}} .wpcw-coupon-image-placeholder' => 'height: {{SIZE}}{{UNIT}}; display: flex; align-items: center; justify-content: center;',
+				],
+			]
+		);
+
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+			'section_style_title',
+			[
+				'label' => esc_html__( 'Título del Cupón', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+
+        $this->add_control(
+			'title_color',
+			[
+				'label' => esc_html__( 'Color', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-title' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'title_typography',
+				'selector' => '{{WRAPPER}} .wpcw-coupon-title',
+			]
+		);
+
+        $this->add_responsive_control(
+			'title_margin',
+			[
+				'label' => esc_html__( 'Margen', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-title' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+			'section_style_code',
+			[
+				'label' => esc_html__( 'Código del Cupón', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+                'condition' => [
+                    'mostrar_codigo' => 'yes',
+                ]
+			]
+		);
+
+        $this->add_control(
+			'code_color',
+			[
+				'label' => esc_html__( 'Color del Texto', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-code' => 'color: {{VALUE}};',
+				],
+			]
+		);
+        $this->add_control(
+			'code_strong_color',
+			[
+				'label' => esc_html__( 'Color del Código (Negrita)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-code strong' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'code_typography',
+				'selector' => '{{WRAPPER}} .wpcw-coupon-code',
+			]
+		);
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'code_strong_typography',
+                'label' => esc_html__( 'Tipografía del Código (Negrita)', 'wp-cupon-whatsapp' ),
+				'selector' => '{{WRAPPER}} .wpcw-coupon-code strong',
+			]
+		);
+
+        $this->add_control(
+			'code_background_color',
+			[
+				'label' => esc_html__( 'Color de Fondo (Solo Código)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-code strong' => 'background-color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->add_responsive_control(
+			'code_padding',
+			[
+				'label' => esc_html__( 'Padding (Solo Código)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-code strong' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->add_responsive_control(
+			'code_border_radius',
+			[
+				'label' => esc_html__( 'Radio del Borde (Solo Código)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-code strong' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->add_responsive_control(
+			'code_margin',
+			[
+				'label' => esc_html__( 'Margen (Bloque de Código)', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-code' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+			'section_style_description',
+			[
+				'label' => esc_html__( 'Descripción del Cupón', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+                'condition' => [
+                    'mostrar_descripcion' => 'yes',
+                ]
+			]
+		);
+
+        $this->add_control(
+			'description_color',
+			[
+				'label' => esc_html__( 'Color', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-description' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'description_typography',
+				'selector' => '{{WRAPPER}} .wpcw-coupon-description',
+			]
+		);
+
+        $this->add_responsive_control(
+			'description_margin',
+			[
+				'label' => esc_html__( 'Margen', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-coupon-description' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+			'section_style_button',
+			[
+				'label' => esc_html__( 'Botón de Canje', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'button_typography',
+				'selector' => '{{WRAPPER}} .wpcw-canjear-cupon-btn',
+			]
+		);
+
+        $this->add_responsive_control(
+			'button_padding',
+			[
+				'label' => esc_html__( 'Padding', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+        $this->add_responsive_control(
+			'button_margin',
+			[
+				'label' => esc_html__( 'Margen', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn' => 'margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->add_group_control(
+			\Elementor\Group_Control_Border::get_type(),
+			[
+				'name' => 'button_border',
+				'selector' => '{{WRAPPER}} .wpcw-canjear-cupon-btn',
+			]
+		);
+
+        $this->add_responsive_control(
+			'button_border_radius',
+			[
+				'label' => esc_html__( 'Radio del Borde', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+				'size_units' => [ 'px', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+
+        $this->start_controls_tabs( 'button_tabs_style' );
+
+		$this->start_controls_tab(
+			'button_tab_normal',
+			[
+				'label' => esc_html__( 'Normal', 'wp-cupon-whatsapp' ),
+			]
+		);
+
+        $this->add_control(
+			'button_color_normal',
+			[
+				'label' => esc_html__( 'Color del Texto', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->add_control(
+			'button_bg_color_normal',
+			[
+				'label' => esc_html__( 'Color de Fondo', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn' => 'background-color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->end_controls_tab();
+
+        $this->start_controls_tab(
+			'button_tab_hover',
+			[
+				'label' => esc_html__( 'Hover', 'wp-cupon-whatsapp' ),
+			]
+		);
+
+        $this->add_control(
+			'button_color_hover',
+			[
+				'label' => esc_html__( 'Color del Texto', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn:hover' => 'color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->add_control(
+			'button_bg_color_hover',
+			[
+				'label' => esc_html__( 'Color de Fondo', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn:hover' => 'background-color: {{VALUE}};',
+				],
+			]
+		);
+
+        $this->add_control(
+			'button_border_color_hover',
+			[
+				'label' => esc_html__( 'Color del Borde', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-canjear-cupon-btn:hover' => 'border-color: {{VALUE}};',
+				],
+                'condition' => [
+                    'button_border_border!' => '', // Only if border type is set
+                ]
+			]
+		);
+
+        $this->end_controls_tab();
+		$this->end_controls_tabs();
+        $this->end_controls_section();
+
+
+	}
+
+	/**
+	 * Render Lista de Cupones widget output on the frontend.
+	 *
+	 * Written in PHP and used to generate the final HTML.
+	 *
+	 * @since 1.1.0
+	 * @access protected
+	 */
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+        if ( 'mis_cupones' === $settings['tipo_cupon'] && ! is_user_logged_in() ) {
+            if ( ! empty( $settings['mensaje_no_logueado'] ) ) {
+                echo '<p class="wpcw-login-required">' . esc_html( $settings['mensaje_no_logueado'] );
+                if ( ! empty( $settings['enlace_login']['url'] ) ) {
+                    $this->add_link_attributes( 'login_link', $settings['enlace_login'] );
+                    echo ' <a ' . $this->get_render_attribute_string( 'login_link' ) . '>' . esc_html__( 'Inicia sesión aquí.', 'wp-cupon-whatsapp' ) . '</a>';
+                }
+                echo '</p>';
+            }
+            return;
+        }
+
+        $query_args = [
+            'post_type'      => 'shop_coupon',
+            'post_status'    => 'publish',
+            'posts_per_page' => $settings['numero_cupones'],
+            'orderby'        => $settings['ordenar_por'],
+            'order'          => $settings['orden'],
+            'meta_query'     => [
+                'relation' => 'AND',
+            ],
+        ];
+
+        if ( 'mis_cupones' === $settings['tipo_cupon'] ) {
+            $query_args['meta_query'][] = [
+                'key'     => '_wpcw_is_loyalty_coupon',
+                'value'   => 'yes',
+                'compare' => '=',
+            ];
+            // Aquí podrías añadir más lógica para filtrar cupones de lealtad específicos del usuario si fuera necesario.
+        } else { // publicos
+            $query_args['meta_query'][] = [
+                'key'     => '_wpcw_is_public_coupon',
+                'value'   => 'yes',
+                'compare' => '=',
+            ];
+        }
+
+        $coupons_query = new \WP_Query( $query_args );
+
+        if ( $coupons_query->have_posts() ) :
+            echo '<div class="wpcw-coupons-grid-wrapper">'; // Wrapper for potential pagination or messages
+            echo '<div class="wpcw-coupons-grid">'; // Grid container
+
+            while ( $coupons_query->have_posts() ) : $coupons_query->the_post();
+                $coupon_id = get_the_ID();
+                $coupon_title = get_the_title();
+                $coupon_code = get_the_title(); // WooCommerce coupon code is the post title
+
+                $coupon_description_full = get_the_excerpt();
+                if (empty($coupon_description_full)) {
+                    $coupon_post_content = get_the_content();
+                    $coupon_description_full = $coupon_post_content;
+                }
+
+                $coupon_description = '';
+                if ( 'yes' === $settings['mostrar_descripcion'] && !empty($coupon_description_full) ) {
+                     $coupon_description = wp_trim_words( $coupon_description_full, $settings['longitud_descripcion'], '...' );
+                     if (empty($coupon_description) && !empty($coupon_description_full)) {
+                        $coupon_description = $coupon_description_full;
+                     }
+                }
+
+
+                $coupon_image_url = '';
+                if ( 'yes' === $settings['mostrar_imagen'] ) {
+                    $coupon_image_id = get_post_meta( $coupon_id, '_wpcw_coupon_image_id', true );
+                    if ( $coupon_image_id ) {
+                        $coupon_image_url = wp_get_attachment_image_url( $coupon_image_id, 'medium' );
+                    }
+                }
+
+                // Render the coupon card using a structure similar to the template
+                ?>
+                <div class="wpcw-coupon-card" id="wpcw-coupon-<?php echo esc_attr( $coupon_id ); ?>">
+                    <?php if ( 'yes' === $settings['mostrar_imagen'] ) : ?>
+                    <div class="wpcw-coupon-image-wrapper">
+                        <?php if ( ! empty( $coupon_image_url ) ) : ?>
+                            <img src="<?php echo esc_url( $coupon_image_url ); ?>" alt="<?php echo esc_attr( $coupon_title ); ?>" class="wpcw-coupon-image"/>
+                        <?php else : ?>
+                            <div class="wpcw-coupon-image-placeholder">
+                                <span><?php esc_html_e( 'Imagen no disponible', 'wp-cupon-whatsapp' ); ?></span>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                    <?php endif; ?>
+
+                    <div class="wpcw-coupon-details">
+                        <h3 class="wpcw-coupon-title"><?php echo esc_html( $coupon_title ); ?></h3>
+
+                        <?php if ( 'yes' === $settings['mostrar_codigo'] && ! empty( $coupon_code ) ) : ?>
+                            <p class="wpcw-coupon-code">
+                                <?php esc_html_e( 'Código:', 'wp-cupon-whatsapp' ); ?>
+                                <strong><?php echo esc_html( $coupon_code ); ?></strong>
+                            </p>
+                        <?php endif; ?>
+
+                        <?php if ( 'yes' === $settings['mostrar_descripcion'] && ! empty( $coupon_description ) ) : ?>
+                        <div class="wpcw-coupon-description">
+                            <?php echo wp_kses_post( wpautop( $coupon_description ) ); ?>
+                        </div>
+                        <?php endif; ?>
+                    </div>
+
+                    <div class="wpcw-coupon-actions">
+                        <button type="button" class="wpcw-canjear-cupon-btn elementor-button" data-coupon-id="<?php echo esc_attr( $coupon_id ); ?>">
+                            <?php echo esc_html( $settings['texto_boton_canje'] ); ?>
+                        </button>
+                    </div>
+                </div>
+                <?php
+            endwhile;
+
+            echo '</div>'; // End .wpcw-coupons-grid
+             echo '</div>'; // End .wpcw-coupons-grid-wrapper
+            wp_reset_postdata();
+        else :
+            echo '<p class="wpcw-no-coupons-message">' . esc_html( $settings['mensaje_no_cupones'] ) . '</p>';
+        endif;
+	}
+
+	/**
+	 * Render Lista de Cupones widget output in the editor.
+	 *
+	 * Written as a Backbone JavaScript template and used to generate the live preview.
+	 *
+	 * @since 1.1.0
+	 * @access protected
+	 */
+	protected function _content_template() {
+        ?>
+        <#
+        if ( 'mis_cupones' === settings.tipo_cupon && ! elementor.config.user.id ) { // Approx check for logged out
+            if ( settings.mensaje_no_logueado ) {
+                #>
+                <p class="wpcw-login-required">{{{ settings.mensaje_no_logueado }}}
+                <# if ( settings.enlace_login.url ) { #>
+                    <a href="{{ settings.enlace_login.url }}">
+                        <?php esc_html_e( 'Inicia sesión aquí.', 'wp-cupon-whatsapp' ); ?>
+                    </a>
+                <# } #>
+                </p>
+                <#
+            }
+            return;
+        }
+
+        // In the editor, we can't execute PHP WP_Query.
+        // We'll show a placeholder or a message.
+        // For a better preview, you might use Elementor's JS hooks to fetch data via AJAX.
+        #>
+        <div class="wpcw-coupons-grid-wrapper">
+            <div class="wpcw-coupons-grid">
+                <#
+                var mockCoupons = 3; // Show 3 mock coupons in editor
+                if ( settings.numero_cupones != -1 && settings.numero_cupones < mockCoupons) {
+                    mockCoupons = settings.numero_cupones;
+                }
+                if ( settings.numero_cupones == 0) mockCoupons = 0;
+
+
+                if ( mockCoupons > 0 ) {
+                    for ( var i = 0; i < mockCoupons; i++ ) {
+                        var coupon_id = 'mock_id_' + i;
+                        var coupon_title = '<?php esc_html_e( "Título del Cupón de Ejemplo", "wp-cupon-whatsapp" ); ?> ' + (i+1);
+                        var coupon_code = '<?php esc_html_e( "EJEMPLO", "wp-cupon-whatsapp" ); ?>' + (i+1);
+                        var coupon_description_full = '<?php esc_html_e( "Esta es una breve descripción del cupón de ejemplo para mostrar cómo se verá. Puedes personalizar esto.", "wp-cupon-whatsapp" ); ?>';
+                        var coupon_description = '';
+                        if ( 'yes' === settings.mostrar_descripcion && coupon_description_full ) {
+                             coupon_description = coupon_description_full.split(' ').slice(0, settings.longitud_descripcion).join(' ') + '...';
+                        }
+                        var coupon_image_url = ''; // Placeholder or a default image URL
+                        if ( 'yes' === settings.mostrar_imagen ) {
+                             coupon_image_url = '<?php echo \Elementor\Utils::get_placeholder_image_src(); ?>';
+                        }
+                #>
+                <div class="wpcw-coupon-card" id="wpcw-coupon-{{ coupon_id }}">
+                    <# if ( 'yes' === settings.mostrar_imagen ) { #>
+                    <div class="wpcw-coupon-image-wrapper">
+                        <# if ( coupon_image_url ) { #>
+                            <img src="{{ coupon_image_url }}" alt="{{ coupon_title }}" class="wpcw-coupon-image"/>
+                        <# } else { #>
+                            <div class="wpcw-coupon-image-placeholder">
+                                <span><?php esc_html_e( 'Imagen no disponible', 'wp-cupon-whatsapp' ); ?></span>
+                            </div>
+                        <# } #>
+                    </div>
+                    <# } #>
+
+                    <div class="wpcw-coupon-details">
+                        <h3 class="wpcw-coupon-title">{{{ coupon_title }}}</h3>
+
+                        <# if ( 'yes' === settings.mostrar_codigo && coupon_code ) { #>
+                            <p class="wpcw-coupon-code">
+                                <?php esc_html_e( 'Código:', 'wp-cupon-whatsapp' ); ?>
+                                <strong>{{{ coupon_code }}}</strong>
+                            </p>
+                        <# } #>
+
+                        <# if ( 'yes' === settings.mostrar_descripcion && coupon_description ) { #>
+                        <div class="wpcw-coupon-description">
+                            {{{ coupon_description }}}
+                        </div>
+                        <# } #>
+                    </div>
+
+                    <div class="wpcw-coupon-actions">
+                        <button type="button" class="wpcw-canjear-cupon-btn elementor-button" data-coupon-id="{{ coupon_id }}">
+                            {{{ settings.texto_boton_canje }}}
+                        </button>
+                    </div>
+                </div>
+                <#
+                    } // end for
+                } else { #>
+                    <p class="wpcw-no-coupons-message">{{{ settings.mensaje_no_cupones }}}</p>
+                <# } #>
+            </div>
+        </div>
+        <?php
+	}
+
+    /**
+     * Add some basic CSS for the grid layout.
+     * More advanced styling should be handled by Elementor controls.
+     */
+    public function __construct($data = [], $args = null) {
+        parent::__construct($data, $args);
+        // Register a general style for the grid, if not already done by another instance.
+        // This is a simple way, could be refined.
+        // wp_register_style( 'wpcw-elementor-grid', false ); // Bogus handle
+        // wp_add_inline_style( 'wpcw-elementor-grid', $this->get_grid_styles() );
+        // add_action('elementor/frontend/after_enqueue_styles', [$this, 'enqueue_widget_styles']);
+
+        // The styles are now primarily handled by selector-based controls.
+        // However, a base style for the grid display itself is good.
+    }
+    /*
+    public function enqueue_widget_styles() {
+        // Inline styles are better handled by Elementor's CSS generation based on controls.
+        // If truly global styles for the widget are needed and not achievable via controls,
+        // they can be enqueued here or in the main addon class.
+        $css = ".wpcw-coupons-grid { display: grid; gap: 15px; }"; // Default gap
+        // This is just an example, real styling is done via controls.
+        // wp_add_inline_style( 'elementor-frontend', $css ); // Add to a common handle
+    }
+    */
+
+    // Fallback if the `coupon-card.php` template is not directly usable
+    // We'll define the structure directly in render() and _content_template()
+}
+
+// The file should not have a closing PHP tag if it's all PHP
+// ?> // Removed closing tag

--- a/elementor/widgets/widget-formulario-adhesion.php
+++ b/elementor/widgets/widget-formulario-adhesion.php
@@ -1,0 +1,719 @@
+<?php
+/**
+ * Elementor Formulario de Solicitud de Adhesión Widget.
+ *
+ * Elementor widget that displays the WPCW application form.
+ *
+ * @since 1.1.0
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+class WPCW_Elementor_Formulario_Adhesion_Widget extends \Elementor\Widget_Base {
+
+	public function get_name() {
+		return 'wpcw-formulario-adhesion';
+	}
+
+	public function get_title() {
+		return esc_html__( 'Formulario Solicitud Adhesión WPCW', 'wp-cupon-whatsapp' );
+	}
+
+	public function get_icon() {
+		return 'eicon-form-horizontal';
+	}
+
+	public function get_categories() {
+		return [ 'wpcw-categoria' ];
+	}
+
+    public function get_script_depends() {
+        $scripts = [];
+        if ( function_exists('wpcw_is_recaptcha_enabled') && wpcw_is_recaptcha_enabled() && function_exists('wpcw_get_recaptcha_site_key') && wpcw_get_recaptcha_site_key() ) {
+            $scripts[] = 'google-recaptcha'; // Handle registered by wpcw_public_enqueue_scripts_styles in recaptcha-integration.php
+        }
+        return $scripts;
+    }
+
+
+	protected function _register_controls() {
+		// Content Tab: Form Texts
+        $this->start_controls_section(
+			'section_content_form_texts',
+			[
+				'label' => esc_html__( 'Textos del Formulario', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
+			]
+		);
+
+        $this->add_control(
+			'legend_applicant_type',
+			[
+				'label' => esc_html__( 'Leyenda: Tipo de Solicitante', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXT,
+				'default' => esc_html__( 'Tipo de Solicitante', 'wp-cupon-whatsapp' ),
+                'dynamic' => [ 'active' => true ],
+			]
+		);
+        $this->add_control(
+			'label_applicant_type_comercio',
+			[
+				'label' => esc_html__( 'Etiqueta: Comercio', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXT,
+				'default' => esc_html__( 'Comercio', 'wp-cupon-whatsapp' ),
+                'dynamic' => [ 'active' => true ],
+			]
+		);
+        $this->add_control(
+			'label_applicant_type_institucion',
+			[
+				'label' => esc_html__( 'Etiqueta: Institución', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXT,
+				'default' => esc_html__( 'Institución', 'wp-cupon-whatsapp' ),
+                'dynamic' => [ 'active' => true ],
+			]
+		);
+
+        $fields = [
+            'wpcw_fantasy_name' => esc_html__( 'Nombre de Fantasía', 'wp-cupon-whatsapp' ),
+            'wpcw_legal_name' => esc_html__( 'Nombre Legal', 'wp-cupon-whatsapp' ),
+            'wpcw_cuit' => esc_html__( 'CUIT', 'wp-cupon-whatsapp' ),
+            'wpcw_contact_person' => esc_html__( 'Persona de Contacto', 'wp-cupon-whatsapp' ),
+            'wpcw_email' => esc_html__( 'Email de Contacto', 'wp-cupon-whatsapp' ),
+            'wpcw_whatsapp' => esc_html__( 'Número de WhatsApp', 'wp-cupon-whatsapp' ),
+            'wpcw_address_main' => esc_html__( 'Dirección Principal', 'wp-cupon-whatsapp' ),
+            'wpcw_description' => esc_html__( 'Descripción del Negocio/Institución', 'wp-cupon-whatsapp' ),
+        ];
+
+        foreach ($fields as $key => $default_label) {
+            $this->add_control(
+                'label_' . $key,
+                [
+                    'label' => sprintf(esc_html__( 'Etiqueta: %s', 'wp-cupon-whatsapp' ), $default_label),
+                    'type' => \Elementor\Controls_Manager::TEXT,
+                    'default' => $default_label,
+                    'dynamic' => [ 'active' => true ],
+                ]
+            );
+        }
+
+        $this->add_control(
+			'text_submit_button',
+			[
+				'label' => esc_html__( 'Texto del Botón de Envío', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXT,
+				'default' => esc_html__( 'Enviar Solicitud', 'wp-cupon-whatsapp' ),
+                'dynamic' => [ 'active' => true ],
+			]
+		);
+
+        $this->add_control(
+			'text_success_message',
+			[
+				'label' => esc_html__( 'Mensaje de Éxito', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::TEXTAREA,
+				'default' => esc_html__( 'Su solicitud ha sido enviada con éxito. Nos pondremos en contacto a la brevedad.', 'wp-cupon-whatsapp' ),
+                'dynamic' => [ 'active' => true ],
+			]
+		);
+
+        $this->end_controls_section();
+
+        // Content Tab: reCAPTCHA
+        if ( function_exists('wpcw_is_recaptcha_enabled') && wpcw_is_recaptcha_enabled() ) {
+            $this->start_controls_section(
+                'section_content_recaptcha',
+                [
+                    'label' => esc_html__( 'Google reCAPTCHA', 'wp-cupon-whatsapp' ),
+                    'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
+                ]
+            );
+            $this->add_control(
+                'info_recaptcha',
+                [
+                    'type' => \Elementor\Controls_Manager::RAW_HTML,
+                    'raw' => __( 'Google reCAPTCHA v2 está activado en los ajustes del plugin y se mostrará en el formulario.', 'wp-cupon-whatsapp' ),
+                    'content_classes' => 'elementor-descriptor',
+                ]
+            );
+            $this->end_controls_section();
+        }
+
+        // Style Tab: Form General
+        $this->start_controls_section(
+			'section_style_form_general',
+			[
+				'label' => esc_html__( 'Formulario General', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+        $this->add_responsive_control(
+			'form_max_width',
+			[
+				'label' => esc_html__( 'Ancho Máximo del Formulario', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SLIDER,
+				'size_units' => [ 'px', '%' ],
+				'range' => [
+					'px' => [ 'min' => 200, 'max' => 1200 ],
+					'%' => [ 'min' => 10, 'max' => 100 ],
+				],
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor' => 'max-width: {{SIZE}}{{UNIT}}; margin-left: auto; margin-right: auto;',
+				],
+			]
+		);
+        $this->end_controls_section();
+
+
+		// Style Tab: Field Labels
+        $this->start_controls_section(
+			'section_style_labels',
+			[
+				'label' => esc_html__( 'Etiquetas de Campos', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+        $this->add_control(
+			'label_color',
+			[
+				'label' => esc_html__( 'Color', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor label' => 'color: {{VALUE}};',
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor legend' => 'color: {{VALUE}};',
+				],
+			]
+		);
+		$this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'label_typography',
+				'selector' => '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor label, {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor legend',
+			]
+		);
+        $this->add_responsive_control(
+			'label_margin_bottom',
+			[
+				'label' => esc_html__( 'Espaciado Inferior', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SLIDER,
+				'size_units' => [ 'px' ],
+				'range' => [ 'px' => [ 'min' => 0, 'max' => 50 ] ],
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor label' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor legend' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+                    '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor fieldset p label' => 'margin-bottom: 0;', // Reset for radio labels
+				],
+			]
+		);
+        $this->end_controls_section();
+
+        // Style Tab: Input Fields
+        $this->start_controls_section(
+			'section_style_fields',
+			[
+				'label' => esc_html__( 'Campos de Entrada (Texto, Email, Tel, Textarea)', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'field_typography',
+				'selector' => '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="text"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="email"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="tel"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor textarea',
+			]
+		);
+        $this->add_control(
+			'field_text_color',
+			[
+				'label' => esc_html__( 'Color del Texto', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="text"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="email"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="tel"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor textarea' => 'color: {{VALUE}};',
+				],
+			]
+		);
+        $this->add_control(
+			'field_background_color',
+			[
+				'label' => esc_html__( 'Color de Fondo', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="text"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="email"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="tel"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor textarea' => 'background-color: {{VALUE}};',
+				],
+			]
+		);
+        $this->add_group_control(
+			\Elementor\Group_Control_Border::get_type(),
+			[
+				'name' => 'field_border',
+				'selector' => '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="text"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="email"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="tel"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor textarea',
+			]
+		);
+        $this->add_responsive_control(
+			'field_border_radius',
+			[
+				'label' => esc_html__( 'Radio del Borde', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="text"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="email"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="tel"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor textarea' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+				],
+			]
+		);
+        $this->add_responsive_control(
+			'field_padding',
+			[
+				'label' => esc_html__( 'Padding', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="text"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="email"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="tel"], {{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor textarea' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}}; width: 100%; box-sizing: border-box;',
+				],
+			]
+		);
+        $this->add_responsive_control(
+			'field_margin_bottom',
+			[
+				'label' => esc_html__( 'Espaciado Inferior del Párrafo Contenedor', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SLIDER,
+				'size_units' => [ 'px' ],
+                'range' => [ 'px' => [ 'min' => 0, 'max' => 60 ] ],
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor p:not(.wpcw-submit-p)' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+				],
+			]
+		);
+        $this->end_controls_section();
+
+        // Style Tab: Submit Button
+        $this->start_controls_section(
+			'section_style_submit_button',
+			[
+				'label' => esc_html__( 'Botón de Envío', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'button_typography',
+				'selector' => '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]',
+			]
+		);
+		$this->add_responsive_control(
+			'button_width',
+			[
+				'label' => esc_html__( 'Ancho del Botón', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::SELECT,
+				'options' => [
+					'auto' => esc_html__( 'Automático', 'wp-cupon-whatsapp' ),
+					'full' => esc_html__( 'Ancho Completo', 'wp-cupon-whatsapp' ),
+                    'custom' => esc_html__( 'Personalizado', 'wp-cupon-whatsapp' ),
+				],
+				'default' => 'auto',
+                'prefix_class' => 'wpcw-submit-button-width-',
+			]
+		);
+        $this->add_responsive_control(
+            'button_custom_width',
+            [
+                'label' => esc_html__( 'Ancho Personalizado', 'wp-cupon-whatsapp' ),
+                'type' => \Elementor\Controls_Manager::SLIDER,
+                'size_units' => [ '%', 'px' ],
+                'range' => [
+                    '%' => [ 'min' => 10, 'max' => 100 ],
+                    'px' => [ 'min' => 50, 'max' => 500 ],
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]' => 'width: {{SIZE}}{{UNIT}};',
+                ],
+                'condition' => [ 'button_width' => 'custom' ],
+            ]
+        );
+        $this->add_responsive_control(
+			'button_align',
+			[
+				'label' => esc_html__( 'Alineación', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::CHOOSE,
+				'options' => [
+					'left' => [ 'title' => esc_html__( 'Izquierda', 'wp-cupon-whatsapp' ), 'icon' => 'eicon-text-align-left' ],
+					'center' => [ 'title' => esc_html__( 'Centro', 'wp-cupon-whatsapp' ), 'icon' => 'eicon-text-align-center' ],
+					'right' => [ 'title' => esc_html__( 'Derecha', 'wp-cupon-whatsapp' ), 'icon' => 'eicon-text-align-right' ],
+				],
+				'selectors' => [
+					'{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor .wpcw-submit-p' => 'text-align: {{VALUE}};',
+				],
+                'condition' => [ 'button_width!' => 'full' ],
+			]
+		);
+        $this->start_controls_tabs( 'tabs_button_style' );
+		$this->start_controls_tab(
+			'tab_button_normal',
+			[ 'label' => esc_html__( 'Normal', 'wp-cupon-whatsapp' ) ]
+		);
+        $this->add_control(
+			'button_text_color',
+			[
+				'label' => esc_html__( 'Color del Texto', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]' => 'color: {{VALUE}};' ],
+			]
+		);
+        $this->add_control(
+			'button_background_color',
+			[
+				'label' => esc_html__( 'Color de Fondo', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]' => 'background-color: {{VALUE}};' ],
+			]
+		);
+        $this->add_group_control(
+			\Elementor\Group_Control_Border::get_type(),
+			[
+				'name' => 'button_border',
+				'selector' => '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]',
+			]
+		);
+        $this->add_responsive_control(
+			'button_border_radius',
+			[
+				'label' => esc_html__( 'Radio del Borde', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', '%' ],
+				'selectors' => [ '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]' => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};' ],
+			]
+		);
+        $this->add_responsive_control(
+			'button_padding',
+			[
+				'label' => esc_html__( 'Padding', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [ '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};' ],
+			]
+		);
+        $this->end_controls_tab();
+		$this->start_controls_tab(
+			'tab_button_hover',
+			[ 'label' => esc_html__( 'Hover', 'wp-cupon-whatsapp' ) ]
+		);
+        $this->add_control(
+			'button_text_color_hover',
+			[
+				'label' => esc_html__( 'Color del Texto', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]:hover' => 'color: {{VALUE}};' ],
+			]
+		);
+        $this->add_control(
+			'button_background_color_hover',
+			[
+				'label' => esc_html__( 'Color de Fondo', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]:hover' => 'background-color: {{VALUE}};' ],
+			]
+		);
+        $this->add_control(
+			'button_border_color_hover',
+			[
+				'label' => esc_html__( 'Color del Borde', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} #wpcw-solicitud-adhesion-form-elementor input[type="submit"]:hover' => 'border-color: {{VALUE}};' ],
+                'condition' => [ 'button_border_border!' => '' ]
+			]
+		);
+        $this->end_controls_tab();
+		$this->end_controls_tabs();
+        $this->end_controls_section();
+
+        // Style Tab: Messages (Error/Success)
+        $this->start_controls_section(
+			'section_style_messages',
+			[
+				'label' => esc_html__( 'Mensajes (Error/Éxito)', 'wp-cupon-whatsapp' ),
+				'tab' => \Elementor\Controls_Manager::TAB_STYLE,
+			]
+		);
+        $this->add_group_control(
+			\Elementor\Group_Control_Typography::get_type(),
+			[
+				'name' => 'message_typography',
+				'selector' => '{{WRAPPER}} .wpcw-form-errors p, {{WRAPPER}} .wpcw-form-success',
+			]
+		);
+        $this->add_control(
+			'success_message_color',
+			[
+				'label' => esc_html__( 'Color Texto Éxito', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} .wpcw-form-success' => 'color: {{VALUE}};' ],
+			]
+		);
+        $this->add_control(
+			'success_message_background_color',
+			[
+				'label' => esc_html__( 'Color Fondo Éxito', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} .wpcw-form-success' => 'background-color: {{VALUE}}; border-color: {{VALUE}}' ],
+			]
+		);
+        $this->add_control(
+			'error_message_color',
+			[
+				'label' => esc_html__( 'Color Texto Error', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} .wpcw-form-errors p' => 'color: {{VALUE}};' ],
+			]
+		);
+        $this->add_control(
+			'error_message_background_color',
+			[
+				'label' => esc_html__( 'Color Fondo Error', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} .wpcw-form-errors' => 'background-color: {{VALUE}}; border-color: {{VALUE}}' ],
+			]
+		);
+        $this->add_responsive_control(
+			'message_padding',
+			[
+				'label' => esc_html__( 'Padding del Mensaje', 'wp-cupon-whatsapp' ),
+				'type' => \Elementor\Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', 'em', '%' ],
+				'selectors' => [
+					'{{WRAPPER}} .wpcw-form-errors' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}}; margin-bottom: 15px; border-width: 1px; border-style: solid;',
+                    '{{WRAPPER}} .wpcw-form-success' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}}; margin-bottom: 15px; border-width: 1px; border-style: solid;',
+                ],
+			]
+		);
+        $this->end_controls_section();
+
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+        $form_processed_successfully = false;
+        $errors = []; // Initialize errors array
+
+        // --- Start Form Processing Logic (similar to shortcode) ---
+        if ( isset( $_POST['wpcw_submit_solicitud_elementor'] ) ) {
+            if ( ! isset( $_POST['wpcw_solicitud_adhesion_nonce_elementor'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['wpcw_solicitud_adhesion_nonce_elementor'] ), 'wpcw_solicitud_adhesion_action_elementor' ) ) {
+                $errors[] = __( 'Error de seguridad. Inténtalo de nuevo.', 'wp-cupon-whatsapp' );
+            } else {
+                if ( function_exists('wpcw_is_recaptcha_enabled') && wpcw_is_recaptcha_enabled() ) {
+                    $recaptcha_token = isset($_POST['g-recaptcha-response']) ? sanitize_text_field($_POST['g-recaptcha-response']) : '';
+                    if ( function_exists('wpcw_verify_recaptcha') && !wpcw_verify_recaptcha($recaptcha_token) ) {
+                        $errors[] = __('La verificación reCAPTCHA ha fallado. Por favor, inténtalo de nuevo.', 'wp-cupon-whatsapp');
+                    }
+                }
+
+                if ( empty( $errors ) ) {
+                    $applicant_type = isset( $_POST['wpcw_applicant_type'] ) ? sanitize_text_field( $_POST['wpcw_applicant_type'] ) : '';
+                    $fantasy_name = isset( $_POST['wpcw_fantasy_name'] ) ? sanitize_text_field( $_POST['wpcw_fantasy_name'] ) : '';
+                    $legal_name = isset( $_POST['wpcw_legal_name'] ) ? sanitize_text_field( $_POST['wpcw_legal_name'] ) : '';
+                    $cuit = isset( $_POST['wpcw_cuit'] ) ? sanitize_text_field( $_POST['wpcw_cuit'] ) : '';
+                    $contact_person = isset( $_POST['wpcw_contact_person'] ) ? sanitize_text_field( $_POST['wpcw_contact_person'] ) : '';
+                    $email = isset( $_POST['wpcw_email'] ) ? sanitize_email( $_POST['wpcw_email'] ) : '';
+                    $whatsapp = isset( $_POST['wpcw_whatsapp'] ) ? sanitize_text_field( $_POST['wpcw_whatsapp'] ) : '';
+
+                    if ( empty( $applicant_type ) ) $errors[] = __( 'Por favor, selecciona el tipo de solicitante.', 'wp-cupon-whatsapp' );
+                    if ( empty( $fantasy_name ) ) $errors[] = __( 'Por favor, introduce el nombre de fantasía.', 'wp-cupon-whatsapp' );
+                    if ( empty( $legal_name ) ) $errors[] = __( 'Por favor, introduce el nombre legal.', 'wp-cupon-whatsapp' );
+                    if ( empty( $cuit ) ) { $errors[] = __( 'Por favor, introduce el CUIT.', 'wp-cupon-whatsapp' ); }
+                    elseif ( ! preg_match( '/^[0-9]{10,11}$/', $cuit ) ) { $errors[] = __( 'Por favor, introduce un CUIT válido (solo números, 10 u 11 dígitos).', 'wp-cupon-whatsapp' );}
+                    if ( empty( $contact_person ) ) $errors[] = __( 'Por favor, introduce el nombre de la persona de contacto.', 'wp-cupon-whatsapp' );
+                    if ( empty( $email ) ) { $errors[] = __( 'Por favor, introduce un email de contacto.', 'wp-cupon-whatsapp' ); }
+                    elseif ( ! is_email( $email ) ) { $errors[] = __( 'Por favor, introduce un email de contacto válido.', 'wp-cupon-whatsapp' ); }
+                    if ( empty( $whatsapp ) ) { $errors[] = __( 'Por favor, introduce un número de WhatsApp.', 'wp-cupon-whatsapp' ); }
+                    elseif ( ! preg_match( '/^[0-9\s\+\(\)-]+$/', $whatsapp ) ) { $errors[] = __( 'Por favor, introduce un número de WhatsApp válido.', 'wp-cupon-whatsapp' ); }
+
+                    if ( empty( $errors ) ) {
+                        $address_main = isset( $_POST['wpcw_address_main'] ) ? sanitize_textarea_field( wp_unslash( $_POST['wpcw_address_main'] ) ) : '';
+                        $description = isset( $_POST['wpcw_description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['wpcw_description'] ) ) : '';
+                        $post_data = [
+                            'post_title'  => $fantasy_name,
+                            'post_content' => $description,
+                            'post_type'   => 'wpcw_application',
+                            'post_status' => 'publish',
+                        ];
+                        $post_id = wp_insert_post( $post_data );
+
+                        if ( ! is_wp_error( $post_id ) && $post_id > 0 ) {
+                            update_post_meta( $post_id, '_wpcw_applicant_type', $applicant_type );
+                            update_post_meta( $post_id, '_wpcw_legal_name', $legal_name );
+                            update_post_meta( $post_id, '_wpcw_cuit', $cuit );
+                            update_post_meta( $post_id, '_wpcw_contact_person', $contact_person );
+                            update_post_meta( $post_id, '_wpcw_email', $email );
+                            update_post_meta( $post_id, '_wpcw_whatsapp', $whatsapp );
+                            update_post_meta( $post_id, '_wpcw_address_main', $address_main );
+                            update_post_meta( $post_id, '_wpcw_application_status', 'pendiente_revision' );
+                            if ( is_user_logged_in() ) {
+                                update_post_meta( $post_id, '_wpcw_created_user_id', get_current_user_id() );
+                            }
+
+                            // Admin Email Notification (copied from shortcode, should be refactored into a function)
+                            $admin_email = get_option( 'admin_email' );
+                            $subject = sprintf( __( 'Nueva Solicitud de Adhesión: %s', 'wp-cupon-whatsapp' ), $fantasy_name );
+                            $message_body = sprintf( __( 'Se ha recibido una nueva solicitud de adhesión para el programa WP Canje Cupon Whatsapp.', 'wp-cupon-whatsapp' ) ) . "\r\n\r\n";
+                            $message_body .= sprintf( __( 'Nombre de Fantasía: %s', 'wp-cupon-whatsapp' ), $fantasy_name ) . "\r\n";
+                            // ... (rest of the email body fields) ...
+                            $edit_link = get_edit_post_link( $post_id );
+                            if ( $edit_link ) {
+                                $message_body .= sprintf( __( 'Puedes revisar y procesar esta solicitud aquí: %s', 'wp-cupon-whatsapp' ), $edit_link ) . "\r\n";
+                            }
+                            $headers = array( 'Content-Type: text/plain; charset=UTF-8' );
+                            wp_mail( $admin_email, $subject, $message_body, $headers );
+
+                            $form_processed_successfully = true;
+                        } else {
+                            $errors[] = __( 'Hubo un error al procesar su solicitud. Por favor, inténtelo de nuevo más tarde.', 'wp-cupon-whatsapp' );
+                        }
+                    }
+                }
+            }
+        }
+        // --- End Form Processing Logic ---
+
+        if ( $form_processed_successfully ) {
+            echo '<div class="wpcw-form-success">' . esc_html( $settings['text_success_message'] ) . '</div>';
+            return; // Don't show the form again
+        }
+
+        if ( ! empty( $errors ) ) {
+            echo '<div class="wpcw-form-errors">';
+            foreach ( $errors as $error ) {
+                echo '<p>' . esc_html( $error ) . '</p>';
+            }
+            echo '</div>';
+        }
+        ?>
+        <form id="wpcw-solicitud-adhesion-form-elementor" method="POST" action="<?php echo esc_url( get_permalink() ); /* Or rely on Elementor's default action which is current page */ ?>">
+            <fieldset>
+                <legend><?php echo esc_html( $settings['legend_applicant_type'] ); ?></legend>
+                <p>
+                    <label>
+                        <input type="radio" name="wpcw_applicant_type" value="comercio" <?php checked( (isset($_POST['wpcw_applicant_type']) && $_POST['wpcw_applicant_type'] === 'comercio'), true, true ); ?><?php echo ( !isset($_POST['wpcw_applicant_type']) ) ? 'checked' : ''; ?>>
+                        <?php echo esc_html( $settings['label_applicant_type_comercio'] ); ?>
+                    </label>
+                </p>
+                <p>
+                    <label>
+                        <input type="radio" name="wpcw_applicant_type" value="institucion" <?php checked( (isset($_POST['wpcw_applicant_type']) && $_POST['wpcw_applicant_type'] === 'institucion'), true, true ); ?>>
+                        <?php echo esc_html( $settings['label_applicant_type_institucion'] ); ?>
+                    </label>
+                </p>
+            </fieldset>
+
+            <?php
+            $form_fields = [
+                'wpcw_fantasy_name' => ['type' => 'text', 'required' => true, 'label_key' => 'label_wpcw_fantasy_name'],
+                'wpcw_legal_name'   => ['type' => 'text', 'required' => true, 'label_key' => 'label_wpcw_legal_name'],
+                'wpcw_cuit'         => ['type' => 'text', 'required' => true, 'label_key' => 'label_wpcw_cuit'],
+                'wpcw_contact_person' => ['type' => 'text', 'required' => true, 'label_key' => 'label_wpcw_contact_person'],
+                'wpcw_email'        => ['type' => 'email', 'required' => true, 'label_key' => 'label_wpcw_email'],
+                'wpcw_whatsapp'     => ['type' => 'tel', 'required' => true, 'label_key' => 'label_wpcw_whatsapp'],
+                'wpcw_address_main' => ['type' => 'textarea', 'required' => false, 'rows' => 3, 'label_key' => 'label_wpcw_address_main'],
+                'wpcw_description'  => ['type' => 'textarea', 'required' => false, 'rows' => 5, 'label_key' => 'label_wpcw_description'],
+            ];
+
+            foreach ($form_fields as $name => $field) :
+                $value = isset( $_POST[$name] ) ? sanitize_text_field( wp_unslash( $_POST[$name] ) ) : '';
+                if ($field['type'] === 'textarea') {
+                    $value = isset( $_POST[$name] ) ? sanitize_textarea_field( wp_unslash( $_POST[$name] ) ) : '';
+                } elseif ($field['type'] === 'email') {
+                     $value = isset( $_POST[$name] ) ? sanitize_email( wp_unslash( $_POST[$name] ) ) : '';
+                }
+            ?>
+            <p>
+                <label for="<?php echo esc_attr( $name ); ?>_elementor"><?php echo esc_html( $settings[$field['label_key']] ); ?></label><br>
+                <?php if ($field['type'] === 'textarea') : ?>
+                    <textarea id="<?php echo esc_attr( $name ); ?>_elementor" name="<?php echo esc_attr( $name ); ?>" rows="<?php echo esc_attr($field['rows']); ?>" <?php if ($field['required']) echo 'required'; ?>><?php echo esc_textarea( $value ); ?></textarea>
+                <?php else : ?>
+                    <input type="<?php echo esc_attr($field['type']); ?>" id="<?php echo esc_attr( $name ); ?>_elementor" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ($field['required']) echo 'required'; ?>>
+                <?php endif; ?>
+            </p>
+            <?php endforeach; ?>
+
+            <?php wp_nonce_field( 'wpcw_solicitud_adhesion_action_elementor', 'wpcw_solicitud_adhesion_nonce_elementor' ); ?>
+
+            <?php
+            if ( function_exists('wpcw_is_recaptcha_enabled') && wpcw_is_recaptcha_enabled() && function_exists('wpcw_display_recaptcha') ) {
+                wpcw_display_recaptcha(); // This function should output the reCAPTCHA HTML
+            }
+            ?>
+
+            <p class="wpcw-submit-p">
+                <input type="submit" name="wpcw_submit_solicitud_elementor" value="<?php echo esc_attr( $settings['text_submit_button'] ); ?>">
+            </p>
+        </form>
+        <?php
+	}
+
+	protected function _content_template() {
+        ?>
+        <#
+        // In editor, just display the form structure. Actual submission won't work.
+        var form_fields = {
+            'wpcw_fantasy_name': {type: 'text', required: true, label_key: 'label_wpcw_fantasy_name'},
+            'wpcw_legal_name': {type: 'text', required: true, label_key: 'label_wpcw_legal_name'},
+            'wpcw_cuit': {type: 'text', required: true, label_key: 'label_wpcw_cuit'},
+            'wpcw_contact_person': {type: 'text', required: true, label_key: 'label_wpcw_contact_person'},
+            'wpcw_email': {type: 'email', required: true, label_key: 'label_wpcw_email'},
+            'wpcw_whatsapp': {type: 'tel', required: true, label_key: 'label_wpcw_whatsapp'},
+            'wpcw_address_main': {type: 'textarea', required: false, rows: 3, label_key: 'label_wpcw_address_main'},
+            'wpcw_description': {type: 'textarea', required: false, rows: 5, label_key: 'label_wpcw_description'},
+        };
+        #>
+        <form id="wpcw-solicitud-adhesion-form-elementor" method="POST" action="">
+            <fieldset>
+                <legend>{{{ settings.legend_applicant_type }}}</legend>
+                <p>
+                    <label>
+                        <input type="radio" name="wpcw_applicant_type" value="comercio" checked>
+                        {{{ settings.label_applicant_type_comercio }}}
+                    </label>
+                </p>
+                <p>
+                    <label>
+                        <input type="radio" name="wpcw_applicant_type" value="institucion">
+                        {{{ settings.label_applicant_type_institucion }}}
+                    </label>
+                </p>
+            </fieldset>
+
+            <# _.each( form_fields, function( field, name ) { #>
+            <p>
+                <label for="{{ name }}_elementor">{{{ settings[field.label_key] }}}</label><br>
+                <# if (field.type === 'textarea') { #>
+                    <textarea id="{{ name }}_elementor" name="{{ name }}" rows="{{ field.rows }}" <# if (field.required) { #>required<# } #>></textarea>
+                <# } else { #>
+                    <input type="{{ field.type }}" id="{{ name }}_elementor" name="{{ name }}" value="" <# if (field.required) { #>required<# } #>>
+                <# } #>
+            </p>
+            <# }); #>
+
+            <?php // Nonce field is not rendered in JS template for security. ?>
+            <?php // reCAPTCHA placeholder for editor if needed ?>
+            <#
+                if (typeof wpcw_is_recaptcha_enabled === 'function' && wpcw_is_recaptcha_enabled()) {
+                    // This is tricky because wpcw_is_recaptcha_enabled is PHP.
+                    // We assume if the section_content_recaptcha control section was added, it's enabled.
+                    // A better way would be to pass a setting or use JS detection if possible.
+                    var siteKey = '<?php echo esc_js(function_exists("wpcw_get_recaptcha_site_key") ? wpcw_get_recaptcha_site_key() : ""); ?>';
+                    if (siteKey) {
+            #>
+                <div class="g-recaptcha-placeholder" style="height:78px; width: 304px; background: #f0f0f0; border: 1px dashed #ccc; display:flex; align-items:center; justify-content:center; margin-bottom: 15px;">
+                    <span style="font-size:12px; color: #777;"><?php esc_html_e( 'reCAPTCHA aquí', 'wp-cupon-whatsapp' ); ?></span>
+                </div>
+            <#      }
+                }
+            #>
+
+
+            <p class="wpcw-submit-p">
+                <input type="submit" name="wpcw_submit_solicitud_elementor" value="{{{ settings.text_submit_button }}}">
+            </p>
+        </form>
+        <?php
+	}
+}

--- a/wp-cupon-whatsapp.php
+++ b/wp-cupon-whatsapp.php
@@ -108,6 +108,12 @@ require_once WPCW_PLUGIN_DIR . 'public/shortcodes.php';
 // Include My Account endpoint functions
 require_once WPCW_PLUGIN_DIR . 'public/my-account-endpoints.php';
 
+// Elementor Addon
+if ( did_action( 'elementor/loaded' ) ) { // Check if Elementor is loaded
+    require_once WPCW_PLUGIN_DIR . 'elementor/elementor-addon.php';
+}
+
+
 // Admin specific includes
 if ( is_admin() ) {
     require_once WPCW_PLUGIN_DIR . 'admin/admin-menu.php';


### PR DESCRIPTION
Se ha añadido la compatibilidad con Elementor al plugin WP Cupón WhatsApp.

Principales cambios:
- Creada una nueva categoría de widgets en Elementor: "WP Cupón WhatsApp".
- Nuevo widget: "Lista de Cupones WPCW". Permite mostrar listas de cupones públicos o de lealtad con amplias opciones de personalización de contenido y estilo.
- Nuevo widget: "Formulario Solicitud Adhesión WPCW". Permite incrustar el formulario de adhesión con opciones de personalización de textos y estilos.
- Los widgets son responsivos y heredan estilos del tema/Elementor, además de ofrecer controles específicos.
- Asegurada la compatibilidad con la funcionalidad existente del plugin (canje de cupones, envío de formulario de adhesión, reCAPTCHA).
- Actualizado el README.md con documentación sobre los nuevos widgets.